### PR TITLE
Removed condition from blocking_downstream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Here's a high level overview of what's available:
             - params: |
                 param1
                 param2
-          condition: FAILURE
           trigger_with_no_parameters: false
           # Below is Optional, values can be SUCCESS, FAILURE, UNSTABLE, never
           fail: FAILURE # Fail this build step if the triggered build is worse or equal to

--- a/lib/jenkins_pipeline_builder/builders.rb
+++ b/lib/jenkins_pipeline_builder/builders.rb
@@ -126,7 +126,7 @@ builder do
             end
           end
           projects params[:project]
-          condition params[:condition] || 'SUCCESS'
+          condition 'ALWAYS'
           triggerWithNoParameters params[:trigger_with_no_parameters] || false
           block do
             if params[:fail] && colors.include?(params[:fail])


### PR DESCRIPTION
The option isn't in the GUI and is not properly defaulted, so it was causing jobs to not block unless you manually set the condition to ALWAYS.
