### PR TITLE
Allow specification of root_pom

### DIFF
--- a/lib/jenkins_pipeline_builder/extensions/publishers.rb
+++ b/lib/jenkins_pipeline_builder/extensions/publishers.rb
@@ -260,7 +260,7 @@ publisher do
       mavenOpts
       jobAdditionalProperties
       mavenInstallationName params[:maven_installation_name] || ''
-      rootPom
+      rootPom params[:root_pom] || ''
       settings class: 'jenkins.mvn.DefaultSettingsProvider'
       globalSettings class: 'jenkins.mvn.DefaultGlobalSettingsProvider'
       usePrivateRepository false

--- a/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
@@ -59,6 +59,17 @@ describe 'publishers' do
       maven_installation_name = sonar_nodes.select { |node| node.name == 'mavenInstallationName' }
       expect(maven_installation_name.first.content).to match 'test'
     end
+
+    it 'populates root pom' do
+      params = { publishers: { sonar_result: { root_pom: 'project_war/pom.xml' } } }
+
+      JenkinsPipelineBuilder.registry.traverse_registry_path('job', params, @n_xml)
+
+      sonar_nodes = @n_xml.root.children.first.children
+      root_pom = sonar_nodes.select { |node| node.name == 'rootPom' }
+      expect(root_pom.first.content).to match 'project_war/pom.xml'
+    end
+
   end
 
   context 'description_setter' do


### PR DESCRIPTION
Sonar can be targeted to a pom file other than /pom.xml. This feature
exposes this configuration to the yaml
