### PR TITLE
Add HipChat notifications (keeping the same config notation as start-not...

### DIFF
--- a/lib/jenkins_pipeline_builder/extensions/job_attributes.rb
+++ b/lib/jenkins_pipeline_builder/extensions/job_attributes.rb
@@ -201,6 +201,12 @@ job_attribute do
     send('jenkins.plugins.hipchat.HipChatNotifier_-HipChatJobProperty') do
       room params[:room]
       startNotification params[:'start-notify'] || false
+      notifySuccess params[:'success-notify'] || true
+      notifyFailure params[:'failure-notify'] || true
+      notifyBackToNormal params[:'normal-notify'] || true
+      notifyAborted params[:'aborted-notify'] || true
+      notifyNotBuilt params[:'notbuilt-notify'] || false
+      notifyUnstable params[:'unstable-notify'] || true
     end
   end
 end


### PR DESCRIPTION
Adding options to HipChat so it can be configured to report on different events (particularly BackToNormal and Failure whilst turning off Success to make Jenkins less noisy in a room). Made it fairly noisy by default and kept the same semantics as 'start-notify'. So a config to only report on error and returning to green build would be:

```
hipchat:
        room: '{{hipchat_room}}'
        start-notify: false
        success-notify: false
        aborted-notify: false
        unstable-notify: false
```

(I can flip the true/false default values the other way too if specifying what _does_ get reported seems cleaner)
