### PR TITLE
fix for when empty hash is returned

### DIFF
--- a/lib/jenkins_pipeline_builder/cli/pipeline.rb
+++ b/lib/jenkins_pipeline_builder/cli/pipeline.rb
@@ -34,7 +34,7 @@ module JenkinsPipelineBuilder
       desc 'bootstrap Path', 'Generates pipeline from folder or a file'
       def bootstrap(path, project_name = nil)
         failed = Helper.setup(parent_options).bootstrap(path, project_name)
-        fail 'Encountered error during run' unless failed == false
+        fail 'Encountered error during run' unless failed == false || failed.empty?
       end
 
       desc 'pull_request Path', 'Generates jenkins jobs based on a git pull request.'


### PR DESCRIPTION
Previous fix for exiting with 0 on error didn't account for bootstrap returning a {} on success in addition to a false on success.  This is a bandaid.  Long term we should actually fix the underlying problems here.
