### PR TITLE
Fix view column ordering

### DIFF
--- a/lib/jenkins_pipeline_builder/view.rb
+++ b/lib/jenkins_pipeline_builder/view.rb
@@ -172,7 +172,7 @@ module JenkinsPipelineBuilder
       if type == 'categorizedView'
         column_names << 'Categorized - Job'
       else
-        column_names << 'Name'
+        column_names.insert(2, 'Name')
       end
 
       result = []


### PR DESCRIPTION
When using a listview, the "Name" column will be pushed to the far right. This is because the value is being tacked onto the end of the column_names array.

I have changed this to insert the "Name" column into the 3rd position of the array - thereby matching the default Jenkins listview format.
