### PR TITLE
Standalone jobs cannot be bootstrapped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 Gemfile.lock
 *.gem
 .DS_Store
+.idea

--- a/lib/jenkins_pipeline_builder/generator.rb
+++ b/lib/jenkins_pipeline_builder/generator.rb
@@ -75,13 +75,24 @@ module JenkinsPipelineBuilder
       if projects.any?
         errors = publish_project(project_name)
       else
-        errors = publish_jobs(jobs)
+        errors = publish_jobs(standalone jobs)
       end
       errors.each do |k, v|
         logger.error "Encountered errors compiling: #{k}:"
         logger.error v
       end
       errors
+    end
+
+    # Converts standalone jobs to the format that they have when loaded as part of a project.
+    # This addresses an issue where #pubish_jobs assumes that each job will be wrapped
+    # with in a hash a referenced under a key called :result, which is what happens when
+    # it is loaded as part of a project.
+    #
+    # @return An array of jobs
+    #
+    def standalone(jobs)
+      jobs.map! { |job| { result: job } }
     end
 
     def pull_request(path, project_name)

--- a/lib/jenkins_pipeline_builder/generator.rb
+++ b/lib/jenkins_pipeline_builder/generator.rb
@@ -84,17 +84,6 @@ module JenkinsPipelineBuilder
       errors
     end
 
-    # Converts standalone jobs to the format that they have when loaded as part of a project.
-    # This addresses an issue where #pubish_jobs assumes that each job will be wrapped
-    # with in a hash a referenced under a key called :result, which is what happens when
-    # it is loaded as part of a project.
-    #
-    # @return An array of jobs
-    #
-    def standalone(jobs)
-      jobs.map! { |job| { result: job } }
-    end
-
     def pull_request(path, project_name)
       failed = false
       logger.info "Pull Request Generator Running from path #{path}"
@@ -135,6 +124,17 @@ module JenkinsPipelineBuilder
     #
 
     private
+
+    # Converts standalone jobs to the format that they have when loaded as part of a project.
+    # This addresses an issue where #pubish_jobs assumes that each job will be wrapped
+    # with in a hash a referenced under a key called :result, which is what happens when
+    # it is loaded as part of a project.
+    #
+    # @return An array of jobs
+    #
+    def standalone(jobs)
+      jobs.map! { |job| { result: job } }
+    end
 
     def purge_pull_request_jobs(pull)
       pull.purge.each do |purge_job|

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -1,5 +1,11 @@
 require File.expand_path('../spec_helper', __FILE__)
 
+def cleanup_compiled_xml(job_name)
+  Dir["#{job_name}*.xml"].each do |file|
+    File.delete(file)
+  end
+end
+
 describe JenkinsPipelineBuilder::Generator do
   after :each do
     JenkinsPipelineBuilder.registry.clear_versions
@@ -71,49 +77,37 @@ describe JenkinsPipelineBuilder::Generator do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
         list_installed: { 'description' => '20.0', 'git' => '20.0' })
     end
-    it 'produces no errors while creating pipeline SamplePipeline with view' do
+
+    def bootstrap(fixture_path, job_name)
       @generator.debug = true
-      job_name = 'SamplePipeline'
-      path = File.expand_path('../fixtures/generator_tests/sample_pipeline', __FILE__)
-      errors = @generator.bootstrap(path, job_name)
-      expect(errors.empty?).to be true
-      Dir["#{job_name}*.xml"].each do |file|
-        File.delete(file)
-      end
+      errors = @generator.bootstrap(fixture_path, job_name)
+      cleanup_compiled_xml(job_name)
+      errors
+    end
+
+    def fixture_path(fixture)
+      File.expand_path("../fixtures/generator_tests/#{fixture}", __FILE__)
+    end
+
+    it 'produces no errors while creating pipeline SamplePipeline with view' do
+      errors = bootstrap(fixture_path('sample_pipeline'), 'SamplePipeline')
+      expect(errors).to be_empty
     end
 
     it 'produces no errors while creating a single job' do
-      @generator.debug = true
-      job_name = 'SamplePipeline'
-      path = File.expand_path('../fixtures/generator_tests/sample_pipeline/SamplePipeline-10-Commit.yaml', __FILE__)
-      errors = @generator.bootstrap(path, job_name)
+      errors = bootstrap(fixture_path('sample_pipeline/SamplePipeline-10-Commit.yaml'), 'SamplePipeline-10-Commit')
       expect(errors).to be_empty
-      Dir["#{job_name}*.xml"].each do |file|
-        File.delete(file)
-      end
     end
 
     it 'produces no errors while creating pipeline TemplatePipeline' do
-      @generator.debug = true
-      job_name = 'TemplatePipeline'
-      path = File.expand_path('../fixtures/generator_tests/template_pipeline', __FILE__)
-      errors = @generator.bootstrap(path, job_name)
-      expect(errors.empty?).to be true
-      Dir["#{job_name}*.xml"].each do |file|
-        File.delete(file)
-      end
+      errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
+      expect(errors).to be_empty
     end
 
     it 'loads extensions in remote dependencies' do
-      @generator.debug = true
-      job_name = 'TemplatePipeline'
-      path = File.expand_path('../fixtures/generator_tests/template_pipeline', __FILE__)
-      errors = @generator.bootstrap(path, job_name)
-      expect(errors.empty?).to be true
+      errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
+      expect(errors).to be_empty
       expect(@generator.module_registry.registry[:job][:wrappers].keys).to include :test_wrapper
-      Dir["#{job_name}*.xml"].each do |file|
-        File.delete(file)
-      end
       @generator.module_registry.registry[:job][:wrappers].delete(:test_wrapper)
     end
     # Things to check for:
@@ -166,9 +160,7 @@ describe JenkinsPipelineBuilder::Generator do
       )
       success = @generator.pull_request(path, job_name)
       expect(success).to be_truthy
-      Dir["#{job_name}*.xml"].each do |file|
-        File.delete(file)
-      end
+      cleanup_compiled_xml(job_name)
     end
     # Things to check for
     # Fail - no PR job type found

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -82,6 +82,17 @@ describe JenkinsPipelineBuilder::Generator do
       end
     end
 
+    it 'produces no errors while creating a single job' do
+      @generator.debug = true
+      job_name = 'SamplePipeline'
+      path = File.expand_path('../fixtures/generator_tests/sample_pipeline/SamplePipeline-10-Commit.yaml', __FILE__)
+      errors = @generator.bootstrap(path, job_name)
+      expect(errors).to be_empty
+      Dir["#{job_name}*.xml"].each do |file|
+        File.delete(file)
+      end
+    end
+
     it 'produces no errors while creating pipeline TemplatePipeline' do
       @generator.debug = true
       job_name = 'TemplatePipeline'


### PR DESCRIPTION
This is a minimal fix for an issue where bootstrapping of standalone jobs fails, due to a difference in the job data structure compared to when the job is loaded in the context of a project.

A little code clean-up to follow in a subsequent pull request.