### PR TITLE
Allow the command line to accept either an IP or URL for talking to the Jenkins server.

### DIFF
--- a/lib/jenkins_pipeline_builder/cli/base.rb
+++ b/lib/jenkins_pipeline_builder/cli/base.rb
@@ -28,7 +28,7 @@ module JenkinsPipelineBuilder
       class_option :username, aliases:  '-u', desc:  'Name of Jenkins user'
       class_option :password, aliases:  '-p', desc:  'Password of Jenkins user'
       class_option :password_base64, aliases:  '-b', desc:  'Base 64 encoded password of Jenkins user'
-      class_option :server_ip, aliases:  '-s', desc:  'Jenkins server IP address'
+      class_option :server, aliases:  '-s', desc:  'Jenkins server IP address or URL'
       class_option :server_port, aliases:  '-o', desc:  'Jenkins port'
       class_option :creds_file, aliases:  '-c', desc:  'Credentials file for communicating with Jenkins server'
       class_option :debug, type: :boolean, aliases: '-d', desc: 'Run in debug mode (no Jenkins changes)', default: false

--- a/lib/jenkins_pipeline_builder/cli/helper.rb
+++ b/lib/jenkins_pipeline_builder/cli/helper.rb
@@ -68,7 +68,7 @@ module JenkinsPipelineBuilder
         generator
       end
 
-      def process_cli_creds(options)
+      def self.process_cli_creds(options)
         creds = {}.with_indifferent_access.merge options
         begin
           IPAddr.new(creds[:server])

--- a/lib/jenkins_pipeline_builder/cli/helper.rb
+++ b/lib/jenkins_pipeline_builder/cli/helper.rb
@@ -57,7 +57,7 @@ module JenkinsPipelineBuilder
         else
           msg = 'Credentials are not set. Please pass them as parameters or'
           msg << ' set them in the default credentials file'
-          puts msg
+          $stderr.puts msg
           exit 1
         end
 
@@ -71,8 +71,13 @@ module JenkinsPipelineBuilder
         creds = {}.with_indifferent_access.merge options
         if creds[:server] =~ Resolv::AddressRegex
           creds[:server_ip] = creds.delete :server
-        else
+        elsif creds[:server] =~ URI.regexp
           creds[:server_url] = creds.delete :server
+        else
+          msg = "server given (#{creds[:server]}) is neither a URL nor an IP."
+          msg << ' Please pass either a valid IP address or valid URI'
+          $stderr.puts msg
+          exit 1
         end
         creds
       end

--- a/lib/jenkins_pipeline_builder/cli/helper.rb
+++ b/lib/jenkins_pipeline_builder/cli/helper.rb
@@ -27,7 +27,6 @@ require 'jenkins_api_client'
 require 'open-uri'
 require 'zlib'
 require 'archive/tar/minitar'
-require 'ipaddr'
 
 module JenkinsPipelineBuilder
   module CLI
@@ -70,10 +69,9 @@ module JenkinsPipelineBuilder
 
       def self.process_cli_creds(options)
         creds = {}.with_indifferent_access.merge options
-        begin
-          IPAddr.new(creds[:server])
+        if creds[:server] =~ Resolv::AddressRegex
           creds[:server_ip] = creds.delete :server
-        rescue IPAddr::InvalidAddressError
+        else
           creds[:server_url] = creds.delete :server
         end
         creds

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -96,6 +96,7 @@ describe JenkinsPipelineBuilder::CLI::Helper do
       end
 
       it 'should puts and error to stdout and exit if no credentials are passed' do
+        expect(File).to receive(:exist?).and_return(false)
         expect($stderr).to receive(:puts).with(/Credentials are not set/)
         expect { described_class.setup({}) }.to raise_error(SystemExit, 'exit')
       end

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -1,0 +1,42 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+describe JenkinsPipelineBuilder::CLI::Helper do
+
+  let(:generator) do
+    instance_double(
+      JenkinsPipelineBuilder::Generator,
+      :debug= => true
+    )
+  end
+
+  let(:options) do
+    {
+      username: 'username',
+      password: 'password'
+    }
+  end
+
+  let(:expected_options) do
+    {
+      username: 'username',
+      password: 'password'
+    }
+  end
+
+  before(:each) do
+    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
+  end
+
+  it 'should handle server being an ip' do
+    options[:server] = '127.0.0.1'
+    expected_options[:server_ip] = '127.0.0.1'
+    described_class.setup(options)
+  end
+
+  it 'should handle server arg being a url' do
+    options[:server] = 'https://localhost.localdomain'
+    expected_options[:server_url] = 'https://localhost.localdomain'
+    described_class.setup(options)
+  end
+end

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -2,54 +2,105 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe JenkinsPipelineBuilder::CLI::Helper do
 
-  let(:generator) do
-    instance_double(
-      JenkinsPipelineBuilder::Generator,
-      :debug= => true
-    )
-  end
 
-  let(:options) do
-    {
-      username: 'username',
-      password: 'password'
-    }
-  end
+  context '#setup' do
+    let(:generator) do
+      instance_double(
+        JenkinsPipelineBuilder::Generator,
+        :debug= => true
+      )
+    end
 
-  let(:expected_options) do
-    {
-      username: 'username',
-      password: 'password'
-    }
-  end
+    before(:each) do
+      allow(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
+    end
 
-  it 'should handle server arg being an ipv4 address' do
-    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
-    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
-    options[:server] = '127.0.0.1'
-    expected_options[:server_ip] = '127.0.0.1'
-    described_class.setup(options)
-  end
+    context 'username and password given' do
+      let(:options) do
+        {
+          username: 'username',
+          password: 'password'
+        }
+      end
 
-  it 'should handle server arg being an ipv6 address' do
-    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
-    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
-    options[:server] = '::1'
-    expected_options[:server_ip] = '::1'
-    described_class.setup(options)
-  end
+      let(:expected_options) do
+        {
+          username: 'username',
+          password: 'password'
+        }
+      end
 
-  it 'should handle server arg being a url' do
-    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
-    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
-    options[:server] = 'https://localhost.localdomain'
-    expected_options[:server_url] = 'https://localhost.localdomain'
-    described_class.setup(options)
-  end
+      it 'should handle server arg being an ipv4 address' do
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        options[:server] = '127.0.0.1'
+        expected_options[:server_ip] = '127.0.0.1'
+        described_class.setup(options)
+      end
 
-  it 'should puts an error to stdout and exit if server is invalid' do
-    options[:server] = 'not_valid_at_all'
-    expect($stderr).to receive(:puts).with(/server given \(not_valid_at_all\)/)
-    expect { described_class.setup(options) }.to raise_error(SystemExit, 'exit')
+      it 'should handle server arg being an ipv6 address' do
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        options[:server] = '::1'
+        expected_options[:server_ip] = '::1'
+        described_class.setup(options)
+      end
+
+      it 'should handle server arg being a url' do
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        options[:server] = 'https://localhost.localdomain'
+        expected_options[:server_url] = 'https://localhost.localdomain'
+        described_class.setup(options)
+      end
+
+      it 'should puts an error to stdout and exit if server is invalid' do
+        options[:server] = 'not_valid_at_all'
+        expect($stderr).to receive(:puts).with(/server given \(not_valid_at_all\)/)
+        expect { described_class.setup(options) }.to raise_error(SystemExit, 'exit')
+      end
+    end
+
+    context 'credential file given' do
+      let(:creds_file_base) { 'spec/lib/jenkins_pipeline_builder/fixtures/sample_creds' }
+
+      let(:expected_options) do
+        {
+          'username' => 'username',
+          'password' => 'password',
+          'server_url' => 'https://localhost.localdomain',
+          'server_port' => 8080
+        }
+      end
+
+      it 'should handle credentials passed as a yaml file' do
+        options = {
+          creds_file: "#{creds_file_base}.yaml"
+        }
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        described_class.setup(options)
+      end
+
+      it 'should handle credentials passed as a json file' do
+        options = {
+          creds_file: "#{creds_file_base}.json"
+        }
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        described_class.setup(options)
+      end
+
+      it 'should handle the debug flag' do
+        options = { debug: true }
+        expected_options = {
+          username: :foo,
+          password: :bar,
+          server_ip: :baz
+        }
+        expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+        described_class.setup(options)
+      end
+
+      it 'should puts and error to stdout and exit if no credentials are passed' do
+        expect($stderr).to receive(:puts).with(/Credentials are not set/)
+        expect { described_class.setup({}) }.to raise_error(SystemExit, 'exit')
+      end
+    end
   end
 end

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -1,8 +1,6 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe JenkinsPipelineBuilder::CLI::Helper do
-
-
   context '#setup' do
     let(:generator) do
       instance_double(

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -28,9 +28,15 @@ describe JenkinsPipelineBuilder::CLI::Helper do
     expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
   end
 
-  it 'should handle server arg being an ip' do
+  it 'should handle server arg being an ipv4 address' do
     options[:server] = '127.0.0.1'
     expected_options[:server_ip] = '127.0.0.1'
+    described_class.setup(options)
+  end
+
+  it 'should handle server arg being an ipv6 address' do
+    options[:server] = '::1'
+    expected_options[:server_ip] = '::1'
     described_class.setup(options)
   end
 

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -23,26 +23,33 @@ describe JenkinsPipelineBuilder::CLI::Helper do
     }
   end
 
-  before(:each) do
+  it 'should handle server arg being an ipv4 address' do
     expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
     expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
-  end
-
-  it 'should handle server arg being an ipv4 address' do
     options[:server] = '127.0.0.1'
     expected_options[:server_ip] = '127.0.0.1'
     described_class.setup(options)
   end
 
   it 'should handle server arg being an ipv6 address' do
+    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
     options[:server] = '::1'
     expected_options[:server_ip] = '::1'
     described_class.setup(options)
   end
 
   it 'should handle server arg being a url' do
+    expect(JenkinsPipelineBuilder).to receive(:credentials=).with(expected_options)
+    expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
     options[:server] = 'https://localhost.localdomain'
     expected_options[:server_url] = 'https://localhost.localdomain'
     described_class.setup(options)
+  end
+
+  it 'should puts an error to stdout and exit if server is invalid' do
+    options[:server] = 'not_valid_at_all'
+    expect($stderr).to receive(:puts).with(/server given \(not_valid_at_all\)/)
+    expect { described_class.setup(options) }.to raise_error(SystemExit, 'exit')
   end
 end

--- a/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/cli/helper_spec.rb
@@ -28,7 +28,7 @@ describe JenkinsPipelineBuilder::CLI::Helper do
     expect(JenkinsPipelineBuilder).to receive(:generator).and_return(generator)
   end
 
-  it 'should handle server being an ip' do
+  it 'should handle server arg being an ip' do
     options[:server] = '127.0.0.1'
     expected_options[:server_ip] = '127.0.0.1'
     described_class.setup(options)

--- a/spec/lib/jenkins_pipeline_builder/fixtures/sample_creds.json
+++ b/spec/lib/jenkins_pipeline_builder/fixtures/sample_creds.json
@@ -1,0 +1,6 @@
+{
+  "server_url": "https://localhost.localdomain",
+  "server_port": 8080,
+  "username": "username",
+  "password": "password"
+}

--- a/spec/lib/jenkins_pipeline_builder/fixtures/sample_creds.yaml
+++ b/spec/lib/jenkins_pipeline_builder/fixtures/sample_creds.yaml
@@ -1,0 +1,4 @@
+server_url: https://localhost.localdomain
+server_port: 8080
+username: username
+password: password


### PR DESCRIPTION
 the -s flag will now support either a server_ip or server_url and pass the correct options to the JenkinsAPI client