### PR TITLE
Adding skipTag to git plugin v2

### DIFF
--- a/lib/jenkins_pipeline_builder/extensions/job_attributes.rb
+++ b/lib/jenkins_pipeline_builder/extensions/job_attributes.rb
@@ -77,8 +77,7 @@ job_attribute do
     # XML preprocessing
     # TODO: Actually figure out how to merge using the builder DSL
     # This delete the things we are going to add later is pretty crappy
-    # Alternately don't use/tweak the xml the api client generates
-    # (which is where I assume this is coming from)
+    # Alternately don't use/tweak the xml the jenkins_api_client generates
     before do |params|
       xpath('//scm/localBranch').remove if params[:local_branch]
       xpath('//scm/recursiveSubmodules').remove if params[:recursive_update]
@@ -126,13 +125,20 @@ job_attribute do
       :refspec,
       :remote_name,
       :remote_url,
+      :skip_tag,
       :wipe_workspace
     ]
 
     before do |params|
       remote_url = xpath('//scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url').first
       params[:remote_url] = remote_url.content if remote_url
+
+      # XML preprocessing
+      # TODO: Actually figure out how to merge using the builder DSL
+      # This delete the things we are going to add later is pretty crappy
+      # Alternately don't use/tweak the xml the jenkins_api_client generates
       xpath('//scm/userRemoteConfigs').remove
+      xpath('//scm/skipTag').remove if params[:skip_tag]
     end
 
     xml path: '//scm' do |params|
@@ -147,6 +153,7 @@ job_attribute do
       end
       doGenerateSubmoduleConfigurations false
       submoduleCfg
+      skipTag params[:skip_tag] if params[:skip_tag]
       extensions do
         if params[:changelog_to_branch]
           opts = params[:changelog_to_branch]

--- a/spec/lib/jenkins_pipeline_builder/extensions/job_attributes_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/job_attributes_spec.rb
@@ -205,7 +205,8 @@ describe 'job_attributes' do
             remote_name: :foo,
             refspec: :refspec,
             remote_url: :remote_url,
-            credentials_id: :creds
+            credentials_id: :creds,
+            skip_tag: true
           },
           scm_url: 'http://foo.com'
         }
@@ -238,6 +239,7 @@ describe 'job_attributes' do
         expect(scm_config.css('includedRegions').first.content).to eq 'included_region'
         expect(scm_config.css('excludedRegions').first.content).to eq 'excluded_region'
         expect(scm_config.css('credentialsId').first.content).to eq 'creds'
+        expect(scm_config.css('skipTag').first.content).to eq 'true'
       end
     end
 


### PR DESCRIPTION
Adding skip_tag to v2 git plugin. This was in v1 and is helpful when using maven or npm to tag the build in git. Using this flag it avoids duplicate tagging when you push up to git.

Not totally necessary, I will probably end up using the git publisher, but nice to have.

Also yes the deleting first is because the jenkins_api_client gives us a base job xml, which includes many fields already on it. So for job_attributes, we end up having to override what they send us.