### PR TITLE
Fix the bad Regex!

### DIFF
--- a/lib/jenkins_pipeline_builder/pull_request_generator.rb
+++ b/lib/jenkins_pipeline_builder/pull_request_generator.rb
@@ -25,7 +25,7 @@ module JenkinsPipelineBuilder
     attr_accessor :open_prs, :application_name
 
     def initialize(defaults = {})
-      @application_name = defaults[:application_name]
+      @application_name = defaults[:application_name] || fail('Please set "application_name" in your project!')
       @open_prs = active_prs defaults[:github_site], defaults[:git_org], defaults[:git_repo_name]
     end
 
@@ -36,7 +36,7 @@ module JenkinsPipelineBuilder
 
     def delete_closed_prs
       return if JenkinsPipelineBuilder.debug
-      jobs_to_delete = JenkinsPipelineBuilder.client.job.list "#{application_name}-PR.*"
+      jobs_to_delete = JenkinsPipelineBuilder.client.job.list "^#{application_name}-PR.*"
       open_prs.each do |n|
         jobs_to_delete.reject! { |j| j.start_with? "#{application_name}-PR#{n}" }
       end

--- a/spec/lib/jenkins_pipeline_builder/pull_request_generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/pull_request_generator_spec.rb
@@ -31,6 +31,11 @@ describe JenkinsPipelineBuilder::PullRequestGenerator do
         JenkinsPipelineBuilder::PullRequestGenerator.new(application_name: 'name')
       end.to raise_error('Please set github_site, git_org and git_repo_name in your project.')
     end
+    it 'fails when application_name is not set' do
+      expect do
+        JenkinsPipelineBuilder::PullRequestGenerator.new(github_site: 'foo', git_org: 'bar', git_repo_name: 'baz')
+      end.to raise_error('Please set "application_name" in your project!')
+    end
     it 'fails when github is not reponding properly' do
       stub_request(:get, url)
         .with(headers: { 'Accept' => '*/*',
@@ -51,7 +56,7 @@ describe JenkinsPipelineBuilder::PullRequestGenerator do
                          'User-Agent' => 'Ruby' })
         .to_return(status: 200, body: open_prs_json, headers: {})
       job = double('job')
-      expect(job).to receive(:list).with("#{application_name}-PR.*").and_return prs
+      expect(job).to receive(:list).with("^#{application_name}-PR.*").and_return prs
       client = double('client', job: job)
       expect(JenkinsPipelineBuilder).to receive(:debug).and_return false
       allow(JenkinsPipelineBuilder).to receive(:client).and_return client
@@ -67,7 +72,7 @@ describe JenkinsPipelineBuilder::PullRequestGenerator do
                          'User-Agent' => 'Ruby' })
         .to_return(status: 200, body: open_prs_json, headers: {})
       job = double('job')
-      expect(job).to receive(:list).with("#{application_name}-PR.*").and_return prs - closed_prs
+      expect(job).to receive(:list).with("^#{application_name}-PR.*").and_return prs - closed_prs
       client = double('client', job: job)
       expect(JenkinsPipelineBuilder).to receive(:debug).and_return false
       allow(JenkinsPipelineBuilder).to receive(:client).and_return client


### PR DESCRIPTION
@slopes321 reported that we have a bad regex in place. Thanks for catching that! 

Also, I am making the application_name variable mandatory since it's kind of a standard now. As far as I can tell by just taking a quick look at your pipeline, application_name is equivalent to job_prefix in there. So, if it's too hard to convert to application_name, we can talk about creating pointers in jenkins_pipeline_builder so that you can name your variables whatever you want. Let's talk about it.