### PR TITLE
Fix Local Extension Overrides

### DIFF
--- a/lib/jenkins_pipeline_builder/extension_set.rb
+++ b/lib/jenkins_pipeline_builder/extension_set.rb
@@ -146,7 +146,8 @@ module JenkinsPipelineBuilder
     end
 
     def versions
-      @versions ||= extensions.each_with_object({}) do |ext, hash|
+      # Don't memoize this, it will prevent local overrides
+      extensions.each_with_object({}) do |ext, hash|
         hash[Gem::Version.new(ext.min_version)] = ext
       end
     end

--- a/spec/lib/jenkins_pipeline_builder/compiler_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/compiler_spec.rb
@@ -24,8 +24,7 @@ describe JenkinsPipelineBuilder::Compiler do
           name: 'DummyPipeline',
           jobs: [
             '{{name}}-00',
-            { '{{name}}-01' => { job_name: '{{name}}-02' }
-          }
+            { '{{name}}-01' => { job_name: '{{name}}-02' } }
           ]
         }
       }

--- a/spec/lib/jenkins_pipeline_builder/extension_dsl_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extension_dsl_spec.rb
@@ -31,7 +31,8 @@ describe 'extension dsl' do
     end
 
     allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-      list_installed: { 'parameterized-trigger' => '20.0' })
+      list_installed: { 'parameterized-trigger' => '20.0' }
+    )
 
     @n_xml = Nokogiri::XML::Builder.new { |xml| xml.builders }.doc
     params = { builders: { shell_command: 'asdf' } }

--- a/spec/lib/jenkins_pipeline_builder/extension_set_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extension_set_spec.rb
@@ -35,6 +35,15 @@ describe JenkinsPipelineBuilder::ExtensionSet do
     end
   end
 
+  context '#versions' do
+    it 'does not memoize itself' do
+      set.add_extension 'builder', '0', description: :first
+      set.versions
+      set.add_extension 'builder', '0', description: :second
+      expect(set.versions[Gem::Version.new('0')].description).to eq :second
+    end
+  end
+
   context '#extension' do
     def new_ext(version = '0.0')
       ext = JenkinsPipelineBuilder::Extension.new

--- a/spec/lib/jenkins_pipeline_builder/extensions/builders_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/builders_spec.rb
@@ -52,7 +52,8 @@ describe 'builders' do
   context 'multi_job builder' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'jenkins-multijob-plugin' => '20.0' })
+        list_installed: { 'jenkins-multijob-plugin' => '20.0' }
+      )
     end
     it 'generates a configuration' do
       params = { builders: { multi_job: { phases: { foo: { jobs: [{ name: 'foo' }] } } } } }
@@ -85,7 +86,8 @@ describe 'builders' do
   context 'maven3' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'maven-plugin' => '20.0' })
+        list_installed: { 'maven-plugin' => '20.0' }
+      )
     end
 
     it 'generates a configuration' do
@@ -102,7 +104,8 @@ describe 'builders' do
   context 'blocking_downstream' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'parameterized-trigger' => '20.0' })
+        list_installed: { 'parameterized-trigger' => '20.0' }
+      )
 
       JenkinsPipelineBuilder.registry.traverse_registry_path('job', params, @n_xml)
 
@@ -143,7 +146,8 @@ describe 'builders' do
     before :each do
       error = ''
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'groovy' => '1.24' })
+        list_installed: { 'groovy' => '1.24' }
+      )
 
       begin
         JenkinsPipelineBuilder.registry.traverse_registry_path('job', params, @n_xml)

--- a/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
@@ -28,7 +28,8 @@ describe 'publishers' do
   context 'sonar publisher' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'sonar' => '20.0' })
+        list_installed: { 'sonar' => '20.0' }
+      )
     end
 
     it 'generates a default configuration' do
@@ -101,7 +102,8 @@ describe 'publishers' do
   context 'description_setter' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'description-setter' => '20.0' })
+        list_installed: { 'description-setter' => '20.0' }
+      )
     end
     it 'generates a configuration' do
       params = { publishers: { description_setter: {} } }
@@ -116,8 +118,8 @@ describe 'publishers' do
   context 'downstream' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'parameterized-trigger' => '20.0'
-    })
+        list_installed: { 'parameterized-trigger' => '20.0' }
+      )
     end
 
     it 'generates a configuration' do
@@ -137,8 +139,8 @@ describe 'publishers' do
   context 'cobertura_report' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'cobertura' => '20.0'
-    })
+        list_installed: { 'cobertura' => '20.0' }
+      )
     end
     it 'generates a configuration' do
       params = { publishers: { cobertura_report: {} } }
@@ -155,8 +157,8 @@ describe 'publishers' do
   context 'email_ext' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'email-ext' => '20.0'
-    })
+        list_installed: { 'email-ext' => '20.0' }
+      )
     end
     it 'generates a configuration' do
       params = { publishers: { email_ext: { triggers: [{ type: :first_failure }] } } }
@@ -174,7 +176,8 @@ describe 'publishers' do
     context '0.1.9' do
       before :each do
         allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-          list_installed: { 'hipchat' => '0.1.9' })
+          list_installed: { 'hipchat' => '0.1.9' }
+        )
       end
       it 'generates a configuration' do
         params = { publishers: { hipchat: {} } }
@@ -197,8 +200,8 @@ describe 'publishers' do
     context '0' do
       before :each do
         expect(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-          list_installed: { 'hipchat' => '0'
-        })
+          list_installed: { 'hipchat' => '0' }
+        )
         puts JenkinsPipelineBuilder.registry.versions
       end
 

--- a/spec/lib/jenkins_pipeline_builder/extensions/triggers_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/triggers_spec.rb
@@ -52,7 +52,8 @@ describe 'triggers' do
   context 'upstream' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'jenkins-multijob-plugin' => '20.0' })
+        list_installed: { 'jenkins-multijob-plugin' => '20.0' }
+      )
     end
 
     it 'generates an unstable configuration' do

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -56,7 +56,8 @@ describe JenkinsPipelineBuilder::Generator do
   describe '#bootstrap' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'description' => '20.0', 'git' => '20.0' })
+        list_installed: { 'description' => '20.0', 'git' => '20.0' }
+      )
     end
 
     def bootstrap(fixture_path, job_name)
@@ -194,8 +195,12 @@ describe JenkinsPipelineBuilder::Generator do
     end
     let(:view_hash) do
       [{ 'view' =>
-        { 'name' => '{{name}} View', 'type' => 'listview', 'description' => '{{description}}', 'regex' => '{{name}}.*' }
-      }]
+        {
+          'name' => '{{name}} View',
+          'type' => 'listview',
+          'description' => '{{description}}',
+          'regex' => '{{name}}.*'
+        } }]
     end
 
     it 'loads a yaml collection from a path' do
@@ -254,7 +259,8 @@ describe JenkinsPipelineBuilder::Generator do
   describe '#file_mode' do
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'description' => '20.0', 'git' => '20.0' })
+        list_installed: { 'description' => '20.0', 'git' => '20.0' }
+      )
     end
     after :each do
       file_paths = ['out/xml/TemplatePipeline-10.xml',

--- a/spec/lib/jenkins_pipeline_builder/module_registry_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/module_registry_spec.rb
@@ -76,7 +76,8 @@ describe JenkinsPipelineBuilder::ModuleRegistry do
 
     before :each do
       allow(JenkinsPipelineBuilder.client).to receive(:plugin).and_return double(
-        list_installed: { 'test_name' => '20.0', 'unorderedTest' => '20.0' })
+        list_installed: { 'test_name' => '20.0', 'unorderedTest' => '20.0' }
+      )
       @n_xml = Nokogiri::XML::Document.new
 
       wrapper do


### PR DESCRIPTION
Currently, you cannot override an extension locally. The extension set memoizes the versions which get set before the local files are loaded, thus ignoring any overrides you have.