### PR TITLE
Let pipeline jobs comment on pull requests

### DIFF
--- a/lib/jenkins_pipeline_builder/extensions/publishers.rb
+++ b/lib/jenkins_pipeline_builder/extensions/publishers.rb
@@ -562,6 +562,7 @@ publisher do
     send('jenkins.plugins.github__pull__request__notifier.GithubPullRequestNotifier') do
       pullRequestNumber params[:pull_request_number]
       groupRepo params[:group_repo]
+      commentOnPr params[:comment_on_pr] || false
     end
   end
 end

--- a/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extensions/publishers_spec.rb
@@ -228,7 +228,15 @@ describe 'publishers' do
       )
     end
     it 'generates a configuration' do
-      params = { publishers: { pull_request_notifier: { pull_request_number: '5', group_repo: 'test/me' } } }
+      params = {
+        publishers: {
+          pull_request_notifier: {
+            pull_request_number: '5',
+            group_repo: 'test/me',
+            comment_on_pr: 'true'
+          }
+        }
+      }
 
       JenkinsPipelineBuilder.registry.traverse_registry_path('job', params, @n_xml)
 
@@ -239,6 +247,24 @@ describe 'publishers' do
       expect(publisher.children[0].content).to eq '5'
       expect(publisher.children[1].name).to eq 'groupRepo'
       expect(publisher.children[1].content).to eq 'test/me'
+      expect(publisher.children[2].name).to eq 'commentOnPr'
+      expect(publisher.children[2].content).to eq 'true'
+    end
+    it 'it does not comment on pull requests by default' do
+      params = {
+        publishers: {
+          pull_request_notifier: {
+            pull_request_number: '5', group_repo: 'test/me'
+          }
+        }
+      }
+
+      JenkinsPipelineBuilder.registry.traverse_registry_path('job', params, @n_xml)
+
+      publisher = @n_xml.root.children.first
+
+      expect(publisher.children[2].name).to eq 'commentOnPr'
+      expect(publisher.children[2].content).to eq 'false'
     end
   end
 


### PR DESCRIPTION
 In newer versions of Jenkins, the github pull request notifier accepts a new checkbox parameter, "Comment on Pull Request", which is Unchecked by default. Older versions of Jenkins always commented on pull requests by default.

Users who want their pipeline jobs to add comments to PR's will need this extension change.

Users will also need to add markup like this in their pipeline YAML files:
```
      - pull_request_notifier:
          pull_request_number: '{{pull_request_number}}'
          group_repo: '{{git_org}}/{{git_repo}}'
          comment_on_pr: true
```

If unspecified, `comment_on_pr` is `false` by default.