### PR TITLE
CD-2416: Add support for preBuildCleanup in .yaml

### DIFF
--- a/pipeline/Jenkins-Pipeline-Builder.yaml
+++ b/pipeline/Jenkins-Pipeline-Builder.yaml
@@ -12,6 +12,9 @@
       - timestamp: true
       - ansicolor: true
       - rvm: "`cat .ruby-version`"
+      - prebuild_cleanup:
+          delete_directories: false
+          cleanup_parameter: 'CLEANUP'
     publishers:
       - junit_result:
           test_results: 'out/**/*.xml'


### PR DESCRIPTION
* Update `Jenkins-Pipeline-Builder.yaml` to add support for the [preBuildCleanup plugin](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.preBuildCleanup)