### PR TITLE
Base branch only flag

### DIFF
--- a/lib/jenkins_pipeline_builder/cli/pipeline.rb
+++ b/lib/jenkins_pipeline_builder/cli/pipeline.rb
@@ -39,9 +39,10 @@ module JenkinsPipelineBuilder
         exit(1)
       end
 
-      desc 'pull_request Path [ProjectName] [BaseBranchOnly]', 'Generates jenkins jobs based on a git pull request.'
-      def pull_request(path, project_name = nil, base_branch_only = false)
-        Helper.setup(parent_options).pull_request(path, project_name, base_branch_only)
+      option :base_branch_only, type: :boolean
+      desc 'pull_request Path [ProjectName] [--base_branch_only]', 'Generates jenkins jobs based on a git pull request.'
+      def pull_request(path, project_name = nil)
+        Helper.setup(parent_options).pull_request(path, project_name, options[:base_branch_only])
       end
 
       desc 'file Path [ProjectName]', 'Does the same thing as bootstrap but doesn\'t actually create jobs on the server'

--- a/lib/jenkins_pipeline_builder/cli/pipeline.rb
+++ b/lib/jenkins_pipeline_builder/cli/pipeline.rb
@@ -31,7 +31,7 @@ module JenkinsPipelineBuilder
         Helper.setup(parent_options).dump(job_name)
       end
 
-      desc 'bootstrap Path', 'Generates pipeline from folder or a file'
+      desc 'bootstrap Path [ProjectName]', 'Generates pipeline from folder or a file'
       def bootstrap(path, project_name = nil)
         failed = Helper.setup(parent_options).bootstrap(path, project_name)
         exit(0) if failed.empty? # weird ordering, but rubocop decrees
@@ -39,12 +39,12 @@ module JenkinsPipelineBuilder
         exit(1)
       end
 
-      desc 'pull_request Path', 'Generates jenkins jobs based on a git pull request.'
-      def pull_request(path, project_name = nil)
-        Helper.setup(parent_options).pull_request(path, project_name)
+      desc 'pull_request Path [ProjectName] [BaseBranchOnly]', 'Generates jenkins jobs based on a git pull request.'
+      def pull_request(path, project_name = nil, base_branch_only = false)
+        Helper.setup(parent_options).pull_request(path, project_name, base_branch_only)
       end
 
-      desc 'file Path', 'Does the same thing as bootstrap but doesn\'t actually create jobs on the server'
+      desc 'file Path [ProjectName]', 'Does the same thing as bootstrap but doesn\'t actually create jobs on the server'
       def file(path, project_name = nil)
         Helper.setup(parent_options).file(path, project_name)
       end

--- a/lib/jenkins_pipeline_builder/extensions/build_steps.rb
+++ b/lib/jenkins_pipeline_builder/extensions/build_steps.rb
@@ -54,7 +54,7 @@ build_step do
               end
             end
           else
-            configs(class: 'empty-list'){}
+            configs(class: 'empty-list') {}
           end
 
           projects state[:name]

--- a/lib/jenkins_pipeline_builder/generator.rb
+++ b/lib/jenkins_pipeline_builder/generator.rb
@@ -56,7 +56,7 @@ module JenkinsPipelineBuilder
       publish(project_name || job_collection.projects.first[:name])
     end
 
-    # rubocop:disable Metrics/AbcSize:
+    # rubocop:disable Metrics/AbcSize
     def pull_request(path, project_name, base_branch_only = false)
       logger.info "Pull Request Generator Running from path #{path}"
       load_job_collection path unless job_collection.loaded?
@@ -66,12 +66,13 @@ module JenkinsPipelineBuilder
       errors = []
       pr_generator.open_prs.each do |pr|
         next if base_branch_only && defaults[:git_branch] != pr[:base]
-        pr_generator.convert! job_collection, pr
+        pr_generator.convert! job_collection, pr[:number]
         error = publish(project_name)
         errors << error unless error.empty?
       end
       errors.empty?
     end
+    # rubocop:enable Metrics/AbcSize
 
     def file(path, project_name)
       logger.info "Generating files from path #{path}"

--- a/lib/jenkins_pipeline_builder/generator.rb
+++ b/lib/jenkins_pipeline_builder/generator.rb
@@ -56,7 +56,7 @@ module JenkinsPipelineBuilder
       publish(project_name || job_collection.projects.first[:name])
     end
 
-    def pull_request(path, project_name)
+    def pull_request(path, project_name, base_branch_only = false)
       logger.info "Pull Request Generator Running from path #{path}"
       load_job_collection path unless job_collection.loaded?
       defaults = job_collection.defaults[:value]
@@ -64,6 +64,7 @@ module JenkinsPipelineBuilder
       pr_generator.delete_closed_prs
       errors = []
       pr_generator.open_prs.each do |pr|
+        next if base_branch_only && defaults[:git_branch] != pr[:base]
         pr_generator.convert! job_collection, pr
         error = publish(project_name)
         errors << error unless error.empty?

--- a/lib/jenkins_pipeline_builder/generator.rb
+++ b/lib/jenkins_pipeline_builder/generator.rb
@@ -56,6 +56,7 @@ module JenkinsPipelineBuilder
       publish(project_name || job_collection.projects.first[:name])
     end
 
+    # rubocop:disable Metrics/AbcSize:
     def pull_request(path, project_name, base_branch_only = false)
       logger.info "Pull Request Generator Running from path #{path}"
       load_job_collection path unless job_collection.loaded?

--- a/lib/jenkins_pipeline_builder/pull_request_generator.rb
+++ b/lib/jenkins_pipeline_builder/pull_request_generator.rb
@@ -29,10 +29,10 @@ module JenkinsPipelineBuilder
       @open_prs = active_prs defaults[:github_site], defaults[:git_org], defaults[:git_repo_name]
     end
 
-    def convert!(job_collection, pr)
-      job_collection.defaults[:value][:application_name] = "#{application_name}-PR#{pr[:number]}"
-      job_collection.defaults[:value][:pull_request_number] = pr[:number].to_s
-      job_collection.jobs.each { |j| override j[:value], pr }
+    def convert!(job_collection, pr_number)
+      job_collection.defaults[:value][:application_name] = "#{application_name}-PR#{pr_number}"
+      job_collection.defaults[:value][:pull_request_number] = pr_number.to_s
+      job_collection.jobs.each { |j| override j[:value], pr_number }
     end
 
     def delete_closed_prs
@@ -46,15 +46,15 @@ module JenkinsPipelineBuilder
 
     private
 
-    def override(job, pr)
+    def override(job, pr_number)
       git_version = JenkinsPipelineBuilder.registry.registry[:job][:scm_params].installed_version
-      job[:scm_branch] = "origin/pr/#{pr[:number]}/head"
+      job[:scm_branch] = "origin/pr/#{pr_number}/head"
       job[:scm_params] ||= {}
-      job[:scm_params][:refspec] = "refs/pull/#{pr[:number]}/head:refs/remotes/origin/pr/#{pr[:number]}/head"
+      job[:scm_params][:refspec] = "refs/pull/#{pr_number}/head:refs/remotes/origin/pr/#{pr_number}/head"
       job[:scm_params][:changelog_to_branch] ||= {}
       if Gem::Version.new(2.0) < git_version
         job[:scm_params][:changelog_to_branch]
-          .merge!(remote: 'origin', branch: "pr/#{pr[:number]}/head")
+          .merge!(remote: 'origin', branch: "pr/#{pr_number}/head")
       end
     end
 

--- a/spec/lib/jenkins_pipeline_builder/extension_set_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/extension_set_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe JenkinsPipelineBuilder::ExtensionSet do
-  subject(:set) { JenkinsPipelineBuilder::ExtensionSet.new('foo'){} }
+  subject(:set) { JenkinsPipelineBuilder::ExtensionSet.new('foo') {} }
 
   before :each do
     set.name 'example'

--- a/spec/lib/jenkins_pipeline_builder/fixtures/generator_tests/pullrequest_pipeline/project.yaml
+++ b/spec/lib/jenkins_pipeline_builder/fixtures/generator_tests/pullrequest_pipeline/project.yaml
@@ -5,6 +5,7 @@
     github_site: 'https://github.com'
     git_org: 'testorg'
     git_repo_name: 'generator_tests'
+    git_branch: 'master'
 
 - project:
     name: PullRequest

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -178,8 +178,8 @@ describe JenkinsPipelineBuilder::Generator do
                              git_repo_name: 'generator_tests'))
         .and_return(pr_generator)
       expect(pr_generator).to receive(:delete_closed_prs)
-      allow(pr_generator).to receive(:convert!) do |job_collection, pr|
-        job_collection.defaults[:value][:application_name] = "testapp-PR#{pr[:number]}"
+      allow(pr_generator).to receive(:convert!) do |job_collection, pr_number|
+        job_collection.defaults[:value][:application_name] = "testapp-PR#{pr_number}"
       end
       expect(pr_generator).to receive(:open_prs).and_return open_prs
       expect(@generator.pull_request(path, job_name)).to be_truthy
@@ -200,7 +200,7 @@ describe JenkinsPipelineBuilder::Generator do
       expect(pr_generator).to receive(:open_prs).and_return open_prs
       expect(pr_generator).to receive(:delete_closed_prs)
       expect(pr_generator).to receive(:convert!)
-        .with(instance_of(JenkinsPipelineBuilder::JobCollection), pr_master)
+        .with(instance_of(JenkinsPipelineBuilder::JobCollection), pr_master[:number])
         .once
 
       expect(@generator.pull_request(path, job_name, true)).to be_truthy

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -190,17 +190,18 @@ describe JenkinsPipelineBuilder::Generator do
       job_name = 'PullRequest'
       pr_generator = double('pr_generator')
       expect(JenkinsPipelineBuilder::PullRequestGenerator).to receive(:new)
-                                                                .with(hash_including(application_name: 'testapp',
-                                                                  github_site: 'https://github.com',
-                                                                  git_org: 'testorg',
-                                                                  git_repo_name: 'generator_tests'))
-                                                                .and_return(pr_generator)
+        .with(hash_including(
+                application_name: 'testapp',
+                github_site: 'https://github.com',
+                git_org: 'testorg',
+                git_repo_name: 'generator_tests'
+        )).and_return(pr_generator)
 
       expect(pr_generator).to receive(:open_prs).and_return open_prs
       expect(pr_generator).to receive(:delete_closed_prs)
       expect(pr_generator).to receive(:convert!)
-                                .with(instance_of(JenkinsPipelineBuilder::JobCollection), pr_master)
-                                .once()
+        .with(instance_of(JenkinsPipelineBuilder::JobCollection), pr_master)
+        .once
 
       expect(@generator.pull_request(path, job_name, true)).to be_truthy
     end

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -133,6 +133,9 @@ describe JenkinsPipelineBuilder::Generator do
       JenkinsPipelineBuilder.registry.registry[:job][:scm_params].clear_installed_version
     end
 
+    let(:pr_master) { { number: 1, base: 'master' } }
+    let(:pr_not_master) { { number: 2, base: 'not-master' } }
+    let(:open_prs) { [pr_master, pr_not_master] }
     let(:path) { File.expand_path('../fixtures/generator_tests/pullrequest_pipeline', __FILE__) }
     it 'produces no errors while creating pipeline PullRequest' do
       job_name = 'PullRequest'
@@ -145,7 +148,7 @@ describe JenkinsPipelineBuilder::Generator do
         .and_return(pr_generator)
       expect(pr_generator).to receive(:delete_closed_prs)
       expect(pr_generator).to receive(:convert!)
-      expect(pr_generator).to receive(:open_prs).and_return [1]
+      expect(pr_generator).to receive(:open_prs).and_return [pr_master]
       success = @generator.pull_request(path, job_name)
       expect(success).to be_truthy
     end
@@ -161,7 +164,7 @@ describe JenkinsPipelineBuilder::Generator do
         .and_return(pr_generator)
       expect(pr_generator).to receive(:delete_closed_prs)
       expect(pr_generator).to receive(:convert!).twice
-      expect(pr_generator).to receive(:open_prs).and_return [1, 2]
+      expect(pr_generator).to receive(:open_prs).and_return open_prs
       expect(@generator.pull_request(path, job_name)).to be_truthy
     end
 
@@ -176,11 +179,30 @@ describe JenkinsPipelineBuilder::Generator do
         .and_return(pr_generator)
       expect(pr_generator).to receive(:delete_closed_prs)
       allow(pr_generator).to receive(:convert!) do |job_collection, pr|
-        job_collection.defaults[:value][:application_name] = "testapp-PR#{pr}"
+        job_collection.defaults[:value][:application_name] = "testapp-PR#{pr[:number]}"
       end
-      expect(pr_generator).to receive(:open_prs).and_return [1, 2]
+      expect(pr_generator).to receive(:open_prs).and_return open_prs
       expect(@generator.pull_request(path, job_name)).to be_truthy
       expect(@generator.job_collection.projects.first[:settings][:application_name]).to eq 'testapp-PR2'
+    end
+
+    it 'correctly creates jobs only for the base branch' do
+      job_name = 'PullRequest'
+      pr_generator = double('pr_generator')
+      expect(JenkinsPipelineBuilder::PullRequestGenerator).to receive(:new)
+                                                                .with(hash_including(application_name: 'testapp',
+                                                                  github_site: 'https://github.com',
+                                                                  git_org: 'testorg',
+                                                                  git_repo_name: 'generator_tests'))
+                                                                .and_return(pr_generator)
+
+      expect(pr_generator).to receive(:open_prs).and_return open_prs
+      expect(pr_generator).to receive(:delete_closed_prs)
+      expect(pr_generator).to receive(:convert!)
+                                .with(instance_of(JenkinsPipelineBuilder::JobCollection), pr_master)
+                                .once()
+
+      expect(@generator.pull_request(path, job_name, true)).to be_truthy
     end
     # Things to check for
     # Fail - no PR job type found

--- a/spec/lib/jenkins_pipeline_builder/pull_request_generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/pull_request_generator_spec.rb
@@ -92,23 +92,22 @@ describe JenkinsPipelineBuilder::PullRequestGenerator do
     end
 
     let(:pr_number) { 8 }
-    let(:pr) { { number: pr_number } }
 
     it 'converts the job application name' do
       collection = job_collection.clone
-      subject.convert! collection, pr
+      subject.convert! collection, pr_number
       expect(collection.defaults[:value][:application_name]).to eq "#{application_name}-PR#{pr_number}"
     end
 
     it 'provides the PR number to the job settings' do
       collection = job_collection.clone
-      subject.convert! collection, pr
+      subject.convert! collection, pr_number
       expect(collection.defaults[:value][:pull_request_number]).to eq pr_number.to_s
     end
 
     it 'overrides the git params' do
       collection = job_collection.clone
-      subject.convert! collection, pr
+      subject.convert! collection, pr_number
       expect(collection.jobs.first[:value]).to eq(
         scm_branch: "origin/pr/#{pr_number}/head",
         scm_params: {
@@ -121,7 +120,7 @@ describe JenkinsPipelineBuilder::PullRequestGenerator do
 
     it 'does not override extra params' do
       collection = job_collection.clone
-      subject.convert! collection, pr
+      subject.convert! collection, pr_number
       expect(collection.jobs.first[:value]).to eq(
         scm_branch: "origin/pr/#{pr_number}/head",
         scm_params: {


### PR DESCRIPTION
## Adds a flag to the CLI's subcommand: pull_request 
This PR adds an optional flag to the CLI's subcommand `pull_request` called `base_branch_only` which tells the pipeline generator to only create PR jobs for this project if the PR's base branch is that of the projects configured `:git_branch` setting.

This flag is optional for backwards compatibility.

## Use Case
As a repo with longer running projects, I would like to only build PR's for my project that are based off my projects configured base branch, so that longer running projects can build differently.

## Examples
1. Existing project in repo FooRepo. Imagine this builds the fooapp code base using JRuby.
```yml
- defaults:
    git_branch: 'master'
    ...
- project:
    name: PullRequest
```
```sh
$ generate pipeline pull_request . ProjectFoo-PR
```
2. New project in repo FooRepo based off master:
Imagine this builds the fooapp code base using MRI/Ruby and will eventually be merged to master but will need its own build jobs while in transition.
```yml
- defaults:
    git_branch: 'master-transitioning'
    ...
- project:
    name: PullRequest
```
```sh
$ generate pipeline pull_request . ProjectFoo-LongerRunningTransition-PR --base_branch_only
```