### PR TITLE
Fixing how JPB pulls down pipeline templates

### DIFF
--- a/lib/jenkins_pipeline_builder/remote_dependencies.rb
+++ b/lib/jenkins_pipeline_builder/remote_dependencies.rb
@@ -89,8 +89,10 @@ module JenkinsPipelineBuilder
       entries[url] = file
       logger.info "Downloading #{url} to #{file}.tar"
       File.open("#{file}.tar", 'w') do |local_file|
-        File.open(url, remote_opts) do |remote_file|
-          local_file.write(Zlib::GzipReader.new(remote_file).read)
+        if URI::DEFAULT_PARSER.regexp
+          URI.parse(url).open(remote_opts) do |remote_file|
+            local_file.write(Zlib::GzipReader.new(remote_file).read)
+          end
         end
       end
 

--- a/lib/jenkins_pipeline_builder/remote_dependencies.rb
+++ b/lib/jenkins_pipeline_builder/remote_dependencies.rb
@@ -89,10 +89,8 @@ module JenkinsPipelineBuilder
       entries[url] = file
       logger.info "Downloading #{url} to #{file}.tar"
       File.open("#{file}.tar", 'w') do |local_file|
-        if URI::DEFAULT_PARSER.regexp
-          URI.parse(url).open(remote_opts) do |remote_file|
-            local_file.write(Zlib::GzipReader.new(remote_file).read)
-          end
+        URI.parse(url).open(remote_opts) do |remote_file|
+          local_file.write(Zlib::GzipReader.new(remote_file).read)
         end
       end
 

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -89,66 +89,52 @@ describe JenkinsPipelineBuilder::Generator do
       expect(errors).to be_empty
     end
 
-    it 'produces no errors while creating pipeline TemplatePipeline' do
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
-      parsed_url = URI.parse('https://www.google.com')
-      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
-      file_object = double
+    context 'when creating pipeline templates' do
+      before(:each) do
+        tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
+        parsed_url = URI.parse('https://www.test.com')
+        file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+        file_object = double
+        allow(URI).to receive(:parse).and_return(parsed_url)
+        allow(parsed_url).to receive(:open).and_yield('A String')
+        allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+        allow(file_object).to receive(:read).and_return(file_contents)
+      end
 
-      allow(URI).to receive(:parse).and_return(parsed_url)
-      allow(parsed_url).to receive(:open).and_yield("A String")
-      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
-      allow(file_object).to receive(:read).and_return(file_contents)
-      errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
-      expect(errors).to be_empty
-    end
+      it 'produces no errors while creating pipeline TemplatePipeline' do
+        errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
+        expect(errors).to be_empty
+      end
 
-    it 'produces no errors while creating pipeline TemplatePipeline_nested' do
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
-      parsed_url = URI.parse('https://www.google.com')
-      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
-      file_object = double
+      it 'overrides the remote dependencies with local ones' do
+        errors = bootstrap(fixture_path('local_override/remote_and_local'), 'TemplatePipeline')
+        expect(errors).to be_empty
+        expect(@generator.job_collection.collection['{{name}}-10'][:value][:description]).to eq('Overridden stuff')
+      end
 
-      allow(URI).to receive(:parse).and_return(parsed_url)
-      allow(parsed_url).to receive(:open).and_yield("A String")
-      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
-      allow(file_object).to receive(:read).and_return(file_contents)
+      it 'loads extensions in remote dependencies' do
+        errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
+        expect(errors).to be_empty
+        expect(@generator.module_registry.registry[:job][:wrappers].keys).to include :test_wrapper
+        @generator.module_registry.registry[:job][:wrappers].delete(:test_wrapper)
+      end
 
-      errors = bootstrap(fixture_path('template_pipeline_nested'), 'TemplatePipeline_nested')
-      expect(errors).to be_empty
-    end
+      it 'fails to override when there are duplicate local items' do
+        expect { bootstrap(fixture_path('local_override/all_local'), 'TemplatePipeline') }.to raise_error(StandardError)
+      end
 
-    it 'loads extensions in remote dependencies' do
-      expect(@generator.module_registry.registry[:job][:wrappers].keys).to include :test_wrapper
-      @generator.module_registry.registry[:job][:wrappers].delete(:test_wrapper)
-    end
-
-    it 'overrides the remote dependencies with local ones' do
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
-      parsed_url = URI.parse('https://www.google.com')
-      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
-      file_object = double
-
-      allow(URI).to receive(:parse).and_return(parsed_url)
-      allow(parsed_url).to receive(:open).and_yield("A String")
-      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
-      allow(file_object).to receive(:read).and_return(file_contents)
-      errors = bootstrap(fixture_path('local_override/remote_and_local'), 'TemplatePipeline')
-      expect(errors).to be_empty
-      expect(@generator.job_collection.collection['{{name}}-10'][:value][:description]).to eq('Overridden stuff')
-    end
-
-    it 'fails to override when there are duplicate local items' do
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
-      parsed_url = URI.parse('https://www.google.com')
-      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
-      file_object = double
-
-      allow(URI).to receive(:parse).and_return(parsed_url)
-      allow(parsed_url).to receive(:open).and_yield("A String")
-      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
-      allow(file_object).to receive(:read).and_return(file_contents)
-      expect { bootstrap(fixture_path('local_override/all_local'), 'TemplatePipeline') }.to raise_error(StandardError)
+      it 'produces no errors while creating pipeline TemplatePipeline_nested' do
+        tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
+        parsed_url = URI.parse('https://www.test.com')
+        file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+        file_object = double
+        allow(URI).to receive(:parse).and_return(parsed_url)
+        allow(parsed_url).to receive(:open).and_yield('A String')
+        allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+        allow(file_object).to receive(:read).and_return(file_contents)
+        errors = bootstrap(fixture_path('template_pipeline_nested'), 'TemplatePipeline_nested')
+        expect(errors).to be_empty
+      end
     end
 
     # Things to check for:
@@ -327,18 +313,19 @@ describe JenkinsPipelineBuilder::Generator do
         File.delete(file_path) if File.exist?(file_path)
       end
     end
+
     it 'generates xml and saves to disk without sending jobs to the server' do
-      job_name = 'TemplatePipeline'
-      path = File.expand_path('fixtures/generator_tests/template_pipeline', __dir__)
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
-      parsed_url = URI.parse('https://www.google.com')
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.test.com')
       file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
       file_object = double
-
       allow(URI).to receive(:parse).and_return(parsed_url)
-      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(parsed_url).to receive(:open).and_yield('A String')
       allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
       allow(file_object).to receive(:read).and_return(file_contents)
+
+      job_name = 'TemplatePipeline'
+      path = File.expand_path('fixtures/generator_tests/template_pipeline', __dir__)
       errors = @generator.file(path, job_name)
       expect(errors).to be_empty
       expect(File.exist?("out/xml/#{job_name}-10.xml")).to be true

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -90,33 +90,64 @@ describe JenkinsPipelineBuilder::Generator do
     end
 
     it 'produces no errors while creating pipeline TemplatePipeline' do
-      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
       parsed_url = URI.parse('https://www.google.com')
-      opened_file = File.open(tar_path)
-      expect(parsed_url).to receive(:open).and_yield(opened_file)
+      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+      file_object = double
+
+      allow(URI).to receive(:parse).and_return(parsed_url)
+      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+      allow(file_object).to receive(:read).and_return(file_contents)
       errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
       expect(errors).to be_empty
     end
 
     it 'produces no errors while creating pipeline TemplatePipeline_nested' do
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.google.com')
+      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+      file_object = double
+
+      allow(URI).to receive(:parse).and_return(parsed_url)
+      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+      allow(file_object).to receive(:read).and_return(file_contents)
+
       errors = bootstrap(fixture_path('template_pipeline_nested'), 'TemplatePipeline_nested')
       expect(errors).to be_empty
     end
 
     it 'loads extensions in remote dependencies' do
-      errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
-      expect(errors).to be_empty
       expect(@generator.module_registry.registry[:job][:wrappers].keys).to include :test_wrapper
       @generator.module_registry.registry[:job][:wrappers].delete(:test_wrapper)
     end
 
     it 'overrides the remote dependencies with local ones' do
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.google.com')
+      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+      file_object = double
+
+      allow(URI).to receive(:parse).and_return(parsed_url)
+      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+      allow(file_object).to receive(:read).and_return(file_contents)
       errors = bootstrap(fixture_path('local_override/remote_and_local'), 'TemplatePipeline')
       expect(errors).to be_empty
       expect(@generator.job_collection.collection['{{name}}-10'][:value][:description]).to eq('Overridden stuff')
     end
 
     it 'fails to override when there are duplicate local items' do
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.google.com')
+      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+      file_object = double
+
+      allow(URI).to receive(:parse).and_return(parsed_url)
+      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+      allow(file_object).to receive(:read).and_return(file_contents)
       expect { bootstrap(fixture_path('local_override/all_local'), 'TemplatePipeline') }.to raise_error(StandardError)
     end
 
@@ -299,6 +330,15 @@ describe JenkinsPipelineBuilder::Generator do
     it 'generates xml and saves to disk without sending jobs to the server' do
       job_name = 'TemplatePipeline'
       path = File.expand_path('fixtures/generator_tests/template_pipeline', __dir__)
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.google.com')
+      file_contents = Zlib::GzipReader.new(File.open(tar_path)).read
+      file_object = double
+
+      allow(URI).to receive(:parse).and_return(parsed_url)
+      allow(parsed_url).to receive(:open).and_yield("A String")
+      allow(Zlib::GzipReader).to receive(:new).and_return(file_object)
+      allow(file_object).to receive(:read).and_return(file_contents)
       errors = @generator.file(path, job_name)
       expect(errors).to be_empty
       expect(File.exist?("out/xml/#{job_name}-10.xml")).to be true

--- a/spec/lib/jenkins_pipeline_builder/generator_spec.rb
+++ b/spec/lib/jenkins_pipeline_builder/generator_spec.rb
@@ -90,6 +90,10 @@ describe JenkinsPipelineBuilder::Generator do
     end
 
     it 'produces no errors while creating pipeline TemplatePipeline' do
+      tar_path = File.join(__dir__, 'fixtures/generator_tests/template_pipeline_nested/jobs.tar.gz')
+      parsed_url = URI.parse('https://www.google.com')
+      opened_file = File.open(tar_path)
+      expect(parsed_url).to receive(:open).and_yield(opened_file)
       errors = bootstrap(fixture_path('template_pipeline'), 'TemplatePipeline')
       expect(errors).to be_empty
     end


### PR DESCRIPTION
# Why

This PR fixes an issue where JPB was unable to resolve and retrieve urls to pipeline templates.